### PR TITLE
Fix a possible "Undefined index: HTTP_USER_AGENT" error log.

### DIFF
--- a/Sources/PortaMx/SubsCompat.php
+++ b/Sources/PortaMx/SubsCompat.php
@@ -297,7 +297,7 @@ function pmx_IsMobile()
 		'mobi',
 	);
 
-	$useragent = strtolower($_SERVER['HTTP_USER_AGENT']);
+	$useragent = isset($_SERVER['HTTP_USER_AGENT']) ? strtolower($_SERVER['HTTP_USER_AGENT']) : '';
 	if(preg_match_all('~'. implode('\b|', $mobileStrings) .'\b~i', $useragent, $device))
 		$modSettings['pmx_isMobile'] = true;
 }


### PR DESCRIPTION
Fixes the following possible error:

```
Undefined index: HTTP_USER_AGENT in /var/www/html/Sources/PortaMx/SubsCompat.php on line 300
```

Pulled in from: https://www.portamx.com/bug-reports/undefined-index-http_user_agent-insubscompatphp-on-line-300/msg21420/#msg21420

Ref: https://github.com/iasdeoupxe/PortaMx-1.54-ecl/pull/5