### PR TITLE
Fix using primary group again in shoutbox instead of using the color

### DIFF
--- a/Sources/PortaMx/Class/shoutbox.php
+++ b/Sources/PortaMx/Class/shoutbox.php
@@ -247,7 +247,7 @@ class pmxc_shoutbox extends PortaMxC_SystemBlock
 				FROM {db_prefix}members AS mem
 				LEFT JOIN {db_prefix}membergroups AS mg ON ('. (!empty($modSettings['permission_enable_postgroups']) ? '(mg.id_group = 0 AND mg.id_group = mem.id_post_group OR mg.id_group > 0 AND mg.id_group = mem.id_group)' : 'mg.id_group = mem.id_group') .' OR FIND_IN_SET(mg.id_group, mem.additional_groups) != 0)
 				WHERE mem.id_member IN ({array_int:members})
-				GROUP BY mem.id_member, mg.online_color',
+				GROUP BY mem.id_member',
 				array(
 					'members' => array_unique($members),
 					'empty' => '',


### PR DESCRIPTION
of the second group.

According to https://www.portamx.com/bug-reports/color-of-second-group-in-shoutbox/msg18985/ the Shoutbox shows the color of the second group instead of the primary group.

This change seems to be introduced in 4e4d19d9a5f2d6e892475da72184a3e427669ff9 to add PostgreSQL support but broke the color for the user above.

Ref: https://github.com/iasdeoupxe/PortaMx-1.54-ecl/pull/6