### PR TITLE
Workaround for "The each() function is deprecated." messages on PHP

### DIFF
--- a/Sources/PortaMx/AdminBlocks.php
+++ b/Sources/PortaMx/AdminBlocks.php
@@ -171,7 +171,7 @@ function PortaMx_AdminBlocks()
 					// move rowpos
 					elseif(!empty($_POST['upd_rowpos']))
 					{
-						list($side) = each($_POST['upd_rowpos']);
+						list($side) = PMX_Each($_POST['upd_rowpos']);
 						list($fromID, $place, $toID) = Pmx_StrToArray($_POST['upd_rowpos'][$side]['rowpos']);
 
 						$request = $smcFunc['db_query']('', '

--- a/Sources/PortaMx/Class/boardnews.php
+++ b/Sources/PortaMx/Class/boardnews.php
@@ -292,7 +292,7 @@ class pmxc_boardnews extends PortaMxC_SystemBlock
 		// find the first post
 		reset($this->posts);
 		for($i = 0; $i < $this->startpage; $i++)
-			list($pid, $post) = each($this->posts);
+			list($pid, $post) = PMX_Each($this->posts);
 
 		// only one? .. clear split
 		if(count($this->posts) - $this->startpage == 1)
@@ -318,7 +318,7 @@ class pmxc_boardnews extends PortaMxC_SystemBlock
 			// write out the left part..
 			while(!empty($this->half))
 			{
-				list($pid, $post) = each($this->posts);
+				list($pid, $post) = PMX_Each($this->posts);
 				$this->pmxc_ShowPost($pid, $post, $isEQ, $this->half == 1);
 				next($this->posts);
 				$this->half--;
@@ -332,14 +332,14 @@ class pmxc_boardnews extends PortaMxC_SystemBlock
 			// shift post by 1..
 			reset($this->posts);
 			for($i = -1; $i < $this->startpage; $i++)
-				list($pid, $post) = each($this->posts);
+				list($pid, $post) = PMX_Each($this->posts);
 
 			// write out the right part..
 			while($this->is_last - $this->spanlast > 0)
 			{
-				list($pid, $post) = each($this->posts);
+				list($pid, $post) = PMX_Each($this->posts);
 				$this->pmxc_ShowPost($pid, $post, $isEQ, $this->is_last == 1 && empty($this->spanlast));
-				list($pid, $post) = each($this->posts);
+				list($pid, $post) = PMX_Each($this->posts);
 				$this->is_last--;
 			}
 
@@ -367,7 +367,7 @@ class pmxc_boardnews extends PortaMxC_SystemBlock
 			// each post in a row
 			while(!empty($this->is_last))
 			{
-				list($pid, $post) = each($this->posts);
+				list($pid, $post) = PMX_Each($this->posts);
 				$this->pmxc_ShowPost($pid, $post, false, $this->is_last == 1);
 				$this->half--;
 				$this->is_last--;

--- a/Sources/PortaMx/Class/boardnewsmult.php
+++ b/Sources/PortaMx/Class/boardnewsmult.php
@@ -311,7 +311,7 @@ class pmxc_boardnewsmult extends PortaMxC_SystemBlock
 		// find the first post
 		reset($this->posts);
 		for($i = 0; $i < $this->startpage; $i++)
-			list($pid, $post) = each($this->posts);
+			list($pid, $post) = PMX_Each($this->posts);
 
 		// only one? .. clear split
 		if(count($this->posts) - $this->startpage == 1)
@@ -337,7 +337,7 @@ class pmxc_boardnewsmult extends PortaMxC_SystemBlock
 			// write out the left part..
 			while(!empty($this->half))
 			{
-				list($pid, $post) = each($this->posts);
+				list($pid, $post) = PMX_Each($this->posts);
 				$this->pmxc_ShowPost($pid, $post, $isEQ, $this->half == 1);
 				next($this->posts);
 				$this->half--;
@@ -351,14 +351,14 @@ class pmxc_boardnewsmult extends PortaMxC_SystemBlock
 			// shift post by 1..
 			reset($this->posts);
 			for($i = -1; $i < $this->startpage; $i++)
-				list($pid, $post) = each($this->posts);
+				list($pid, $post) = PMX_Each($this->posts);
 
 			// write out the right part..
 			while($this->is_last - $this->spanlast > 0)
 			{
-				list($pid, $post) = each($this->posts);
+				list($pid, $post) = PMX_Each($this->posts);
 				$this->pmxc_ShowPost($pid, $post, $isEQ, $this->is_last == 1 && empty($this->spanlast));
-				list($pid, $post) = each($this->posts);
+				list($pid, $post) = PMX_Each($this->posts);
 				$this->is_last--;
 			}
 
@@ -386,7 +386,7 @@ class pmxc_boardnewsmult extends PortaMxC_SystemBlock
 			// each post in a row
 			while(!empty($this->is_last))
 			{
-				list($pid, $post) = each($this->posts);
+				list($pid, $post) = PMX_Each($this->posts);
 				$this->pmxc_ShowPost($pid, $post, false, $this->is_last == 1);
 				$this->half--;
 				$this->is_last--;

--- a/Sources/PortaMx/Class/newposts.php
+++ b/Sources/PortaMx/Class/newposts.php
@@ -284,7 +284,7 @@ class pmxc_newposts extends PortaMxC_SystemBlock
 		// find the first post
 		reset($this->posts);
 		for($i = 0; $i < $this->startpage; $i++)
-			list($pid, $post) = each($this->posts);
+			list($pid, $post) = PMX_Each($this->posts);
 
 		// only one? .. clear split
 		if(count($this->posts) - $this->startpage == 1)
@@ -310,7 +310,7 @@ class pmxc_newposts extends PortaMxC_SystemBlock
 			// write out the left part..
 			while(!empty($this->half))
 			{
-				list($pid, $post) = each($this->posts);
+				list($pid, $post) = PMX_Each($this->posts);
 				$this->pmxc_ShowPost($pid, $post, $isEQ, $this->half == 1);
 				next($this->posts);
 				$this->half--;
@@ -324,14 +324,14 @@ class pmxc_newposts extends PortaMxC_SystemBlock
 			// shift post by 1..
 			reset($this->posts);
 			for($i = -1; $i < $this->startpage; $i++)
-				list($pid, $post) = each($this->posts);
+				list($pid, $post) = PMX_Each($this->posts);
 
 			// write out the right part..
 			while($this->is_last - $this->spanlast > 0)
 			{
-				list($pid, $post) = each($this->posts);
+				list($pid, $post) = PMX_Each($this->posts);
 				$this->pmxc_ShowPost($pid, $post, $isEQ, $this->is_last == 1 && empty($this->spanlast));
-				list($pid, $post) = each($this->posts);
+				list($pid, $post) = PMX_Each($this->posts);
 				$this->is_last--;
 			}
 
@@ -359,7 +359,7 @@ class pmxc_newposts extends PortaMxC_SystemBlock
 			// each post in a row
 			while(!empty($this->is_last))
 			{
-				list($pid, $post) = each($this->posts);
+				list($pid, $post) = PMX_Each($this->posts);
 				$this->pmxc_ShowPost($pid, $post, false, $this->is_last == 1);
 				$this->half--;
 				$this->is_last--;

--- a/Sources/PortaMx/Class/promotedposts.php
+++ b/Sources/PortaMx/Class/promotedposts.php
@@ -372,7 +372,7 @@ class pmxc_promotedposts extends PortaMxC_SystemBlock
 		// find the first post
 		reset($this->posts);
 		for($i = 0; $i < $this->startpage; $i++)
-			list($pid, $post) = each($this->posts);
+			list($pid, $post) = PMX_Each($this->posts);
 
 		// only one? .. clear split
 		if(count($this->posts) - $this->startpage == 1)
@@ -398,7 +398,7 @@ class pmxc_promotedposts extends PortaMxC_SystemBlock
 			// write out the left part..
 			while(!empty($this->half))
 			{
-				list($pid, $post) = each($this->posts);
+				list($pid, $post) = PMX_Each($this->posts);
 				$this->pmxc_ShowPost($pid, $post, $isEQ, $this->half == 1);
 				next($this->posts);
 				$this->half--;
@@ -412,14 +412,14 @@ class pmxc_promotedposts extends PortaMxC_SystemBlock
 			// shift post by 1..
 			reset($this->posts);
 			for($i = -1; $i < $this->startpage; $i++)
-				list($pid, $post) = each($this->posts);
+				list($pid, $post) = PMX_Each($this->posts);
 
 			// write out the right part..
 			while($this->is_last - $this->spanlast > 0)
 			{
-				list($pid, $post) = each($this->posts);
+				list($pid, $post) = PMX_Each($this->posts);
 				$this->pmxc_ShowPost($pid, $post, $isEQ, $this->is_last == 1 && empty($this->spanlast));
-				list($pid, $post) = each($this->posts);
+				list($pid, $post) = PMX_Each($this->posts);
 				$this->is_last--;
 			}
 
@@ -447,7 +447,7 @@ class pmxc_promotedposts extends PortaMxC_SystemBlock
 			// each post in a row
 			while(!empty($this->is_last))
 			{
-				list($pid, $post) = each($this->posts);
+				list($pid, $post) = PMX_Each($this->posts);
 				$this->pmxc_ShowPost($pid, $post, false, $this->is_last == 1);
 				$this->half--;
 				$this->is_last--;

--- a/Sources/PortaMx/Class/rss_reader.php
+++ b/Sources/PortaMx/Class/rss_reader.php
@@ -146,7 +146,7 @@ class pmxc_rss_reader extends PortaMxC_SystemBlock
 			// find the first post
 			reset($this->rsscontent);
 			for($i = 0; $i < $this->startpage; $i++)
-				list($pid, $post) = each($this->rsscontent);
+				list($pid, $post) = PMX_Each($this->rsscontent);
 
 			// only one? .. clear split
 			if(count($this->rsscontent) - $this->startpage == 1)
@@ -172,7 +172,7 @@ class pmxc_rss_reader extends PortaMxC_SystemBlock
 				// write out the left part..
 				while(!empty($this->half))
 				{
-					list($pid, $post) = each($this->rsscontent);
+					list($pid, $post) = PMX_Each($this->rsscontent);
 					$this->pmxc_ShowPost($pid, $post, $isEQ, $this->half == 1);
 					next($this->rsscontent);
 					$this->half--;
@@ -186,14 +186,14 @@ class pmxc_rss_reader extends PortaMxC_SystemBlock
 				// shift post by 1..
 				reset($this->rsscontent);
 				for($i = -1; $i < $this->startpage; $i++)
-					list($pid, $post) = each($this->rsscontent);
+					list($pid, $post) = PMX_Each($this->rsscontent);
 
 				// write out the right part..
 				while($this->is_last - $this->spanlast > 0)
 				{
-					list($pid, $post) = each($this->rsscontent);
+					list($pid, $post) = PMX_Each($this->rsscontent);
 					$this->pmxc_ShowPost($pid, $post, $isEQ, $this->is_last == 1 && empty($this->spanlast));
-					list($pid, $post) = each($this->rsscontent);
+					list($pid, $post) = PMX_Each($this->rsscontent);
 					$this->is_last--;
 				}
 
@@ -221,7 +221,7 @@ class pmxc_rss_reader extends PortaMxC_SystemBlock
 				// each post in a row
 				while(!empty($this->is_last))
 				{
-					list($pid, $post) = each($this->rsscontent);
+					list($pid, $post) = PMX_Each($this->rsscontent);
 					$this->pmxc_ShowPost($pid, $post, false, $this->is_last == 1);
 					$this->half--;
 					$this->is_last--;

--- a/Sources/PortaMx/LoadData.php
+++ b/Sources/PortaMx/LoadData.php
@@ -688,7 +688,7 @@ function PortaMx_getCssDefs(&$css)
 				$ctheme = Pmx_StrToArray($def->attributes['theme']);
 				if(!empty($ctheme))
 				{
-					while(!empty($thmask) && (list($d, $th) = each($ctheme)))
+					while(!empty($thmask) && (list($d, $th) = PMX_Each($ctheme)))
 						$thmask = ($th{0} == '^' ? (substr($th, 1) == $settings['theme_id'] ? false : $thmask) : ($th == $settings['theme_id'] ? $thmask : false));
 				}
 				$result['class'][$cname] = (!empty($thmask) && !empty($ctheme) ? $def->content : '');
@@ -1083,7 +1083,7 @@ function PortaMx_getSettings($from_eclinit = false)
 		$context['pmx']['languages'][$language] = true;
 
 	reset($context['pmx']['languages']);
-	while((list($context['pmx']['currlang'], $sel) = each($context['pmx']['languages'])) && empty($sel));
+	while((list($context['pmx']['currlang'], $sel) = PMX_Each($context['pmx']['languages'])) && empty($sel));
 
 	$context['pmx']['html_footer'] = '
 	<script language="JavaScript" type="text/javascript"><!-- // --><![CDATA[
@@ -1346,7 +1346,7 @@ function PortaMx_getCatByID($cats, $id)
 	if(is_array($cats))
 	{
 		reset($cats);
-		while((list($ofs, $cat) = each($cats)) && empty($fnd))
+		while((list($ofs, $cat) = PMX_Each($cats)) && empty($fnd))
 		{
 			if((is_numeric($id) && $cat['id'] == $id) || (is_string($id) && $cat['name'] == $id))
 				$fnd = $cat;
@@ -1367,7 +1367,7 @@ function PortaMx_getCatByOrder($cats, $order, $dept = 0)
 	reset($cats);
 	do
 	{
-		@list($d, $cat) = each($cats);
+		@list($d, $cat) = PMX_Each($cats);
 		if(isset($cat['childs']) && is_array($cat['childs']) && $cat['catorder'] != $order)
 		{
 			$cat = PortaMx_getCatByOrder($cat['childs'], $order, $dept +1);
@@ -1408,7 +1408,7 @@ function find_cat_insert_pos(&$cats, $cat, $id)
 	$fnd = false;
 	reset($cats);
 
-	while((list($ofs, $data) = each($cats)) && empty($fnd))
+	while((list($ofs, $data) = PMX_Each($cats)) && empty($fnd))
 	{
 		if($data['id'] == $id)
 		{
@@ -1919,7 +1919,7 @@ function pmx_checkCustActions(&$bits, $item, $actname)
 		$autoAny = true;
 
 		// loop through all entrys until we found one
-		while((list($idxPos, $aix) = each($indexes)) && empty($fnd))
+		while((list($idxPos, $aix) = PMX_Each($indexes)) && empty($fnd))
 		{
 			$hideAct = strpos($actions[$keyCtl][$indexes[$idxPos]], '^') === false;
 
@@ -2017,7 +2017,7 @@ function pmx_checkActions($actionlist, $actname, $check = true)
 	if(!empty($getacts) || empty($check))
 	{
 		$actions = explode(';', $actionlist);
-		while(empty($fnd) && (@list($d, $action) = each($actions)) && !empty($action))
+		while(empty($fnd) && (@list($d, $action) = PMX_Each($actions)) && !empty($action))
 		{
 			@list($act, $val) = explode('=', (strpos($action, '=') === false ? $actname .'=' : '') . $action);
 			$val = str_replace(array('*','?'), array('.*','.?'), $val);
@@ -2897,5 +2897,13 @@ function PortaMx_headers($action = '')
 			sCookieValue: \''. $options['collapse_'. $pname] .'\'
 		}
 	});', false, false);
+}
+
+// Custom each() function for deprecated PHP each() function.
+function PMX_Each(&$arr) {
+	$key = key($arr);
+	$result = ($key === null) ? false : [$key, current($arr), 'key' => $key, 'value' => current($arr)];
+	next($arr);
+	return $result;
 }
 ?>


### PR DESCRIPTION
7.2+.

Pulls in the suggestion from:

https://www.portamx.com/smf-2-modifications-and-portamx/smf-now-on-2016-and-supports-php-72-some-fixes-for-pmx-154/msg21496/

to workaround the following on newer PHP versions:

```
8192: The each() function is deprecated. This message will be suppressed on further calls
File: /var/www/html/Sources/PortaMx/LoadData.php
Line: 1086
```

Ref: https://github.com/iasdeoupxe/PortaMx-1.54-ecl/pull/7